### PR TITLE
Fixes: Soy Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.cache
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+
+#
+# soy-syntax makefile
+#
+
+
+QUIET ?= yes
+VERBOSE ?= no
+
+USER ?= $(shell whoami)
+TARGET ?= /Users/$(USER)/Library/Application\ Support/Sublime\ Text\ 3/Packages/Soy
+
+ifeq ($(VERBOSE),yes)
+_RULE =
+POSIX_FLAGS ?= -v
+else
+ifeq ($(QUIET),yes)
+_RULE ?= @
+endif
+endif
+
+SOURCES ?= Preferences/ Snippets/ Syntaxes/ info.plist
+
+all:
+	$(info Installing package...)
+	$(_RULE)mkdir -p $(TARGET) && cp -fr $(POSIX_FLAGS) $(SOURCES) $(TARGET)/
+	$(_RULE)echo "Package installed."
+
+
+.PHONY: all
+

--- a/Preferences/Style: css.tmPreferences
+++ b/Preferences/Style: css.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Style: css</string>
+	<key>scope</key>
+	<string>entity.name.css</string>
+	<key>settings</key>
+	<dict>
+		<key>foreground</key>
+		<string>#BCF1F5</string>
+	</dict>
+	<key>uuid</key>
+	<string>69E9BC3A-510B-4D5D-9B7A-7ECF878871B3</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Soy
 
+_Big thank you to [@medium](https://github.com/medium) and [@anvie](https://github.com/anvie) for creating this, then building on it, before I got my hands in the code_
+
 A [Sublime Text](http://www.sublimetext.com/) Package (and [TextMate](http://macromates.com/) Bundle) for Google [Closure Templates](http://code.google.com/closure/templates/).
 
 The bundle includes syntax highlighting, the ability to compile or evaluate Closure template inline, convenient symbol listing for functions, and a number of snippets.

--- a/Syntaxes/Soy.YAML-tmLanguage
+++ b/Syntaxes/Soy.YAML-tmLanguage
@@ -6,6 +6,8 @@ fileTypes: [soy]
 uuid: C56846DE-CB9A-4DB5-9D38-DC417DEA4D5F
 
 patterns:
+- include: '#namespace'
+
 - include: '#template'
 
 - include: '#if'
@@ -16,9 +18,15 @@ patterns:
 
 - include: '#comment-doc'
 
+- include: '#comment-soy'
+
 - include: '#call'
 
-- include: '#css'
+- include: '#css-dec'
+
+- include: '#css-call'
+
+- include: '#xid'
 
 - include: '#param'
 
@@ -94,13 +102,22 @@ repository:
         '1': {name: support.type.soy}
         '2': {name: variable.parameter.soy}
 
+  comment-soy:
+    name: comment.block.inline.soy
+    begin: (\{\#)
+    beginCaptures:
+      '1': {name: punctuation.definition.comment.begin.soy}
+    end: (\#\})
+    endCaptures:
+      '1': {name: punctuation.definition.comment.end.soy}
+
   comment-line:
     name: comment.line.double-slash.soy
     match: \s*(//).*$\n?
     captures:
       '1': {name: punctuation.definition.comment.soy}
 
-  css:
+  css-dec:
     name: meta.tag.css.soy
     begin: (\{/?)\s*(css)\b
     beginCaptures:
@@ -112,6 +129,31 @@ repository:
     patterns:
     - name: support.constant.soy
       match: \b(LITERAL|REFERENCE|BACKEND_SPECIFIC|GOOG)\b
+
+  css-call:
+    name: meta.call.css.soy
+    begin: (\{/?)\s*(css)\(?\'([\w.]+)\'\)
+    beginCaptures:
+      '1': {name: punctuation.definition.tag.begin.soy}
+      '2': {name: entity.name.tag.soy}
+      '3': {name: entity.name.css.soy}
+    end: (\})
+    endCaptures:
+      '1': {name: punctuation.definition.tag.end.soy}
+    patterns:
+    - name: support.constant.soy
+      match: \b(LITERAL|REFERENCE|BACKEND_SPECIFIC|GOOG)\b
+
+  xid:
+    name: meta.call.xid.soy
+    begin: (\{/?)\s*(xid)\(?\'([\w.]+)\'\)
+    beginCaptures:
+      '1': {name: punctuation.definition.tag.begin.soy}
+      '2': {name: entity.name.tag.soy}
+      '3': {name: entity.name.css.soy}
+    end: (\})
+    endCaptures:
+      '1': {name: punctuation.definition.tag.end.soy}
 
   element-any:
     name: meta.tag.any.soy
@@ -140,6 +182,7 @@ repository:
     - include: '#comment-line'
     - include: '#comment-block'
     - include: '#comment-doc'
+    - include: '#comment-soy'
     - include: '#embedded-code'
     - include: '#element-attribute'
 
@@ -182,7 +225,9 @@ repository:
     - include: '#escaped-char'
     - include: '#if'
     - include: '#call'
-    - include: '#css'
+    - include: '#css-dec'
+    - include: '#css-call'
+    - include: '#xid'
     - include: '#param'
     - include: '#print'
     - include: '#msg'
@@ -238,7 +283,7 @@ repository:
 
   function:
     name: support.function.soy
-    match: \b(isFirst|isLast|index|hasData|length|keys|round|floor|ceiling|min|max|randomInt)\b
+    match: \b(isFirst|isLast|index|hasData|length|keys|round|floor|ceiling|min|max|randomInt|isNonnull)
 
   if:
     name: meta.tag.if.soy
@@ -280,11 +325,45 @@ repository:
         '1': {name: entity.other.attribute-name.soy}
         '2': {name: keyword.operator.soy}
 
-  namespace:
-    match: (namespace|delpackage)\s+([\w\.]+)
+  delpackage:
+    match: (\{)(delpackage)\s+([\w\.]+)(\})
     captures:
-      '1': {name: entity.name.tag.soy}
-      '2': {name: variable.parameter.soy}
+      '1': {name: punctuation.definition.tag.begin.soy}
+      '2': {name: entity.name.tag.soy}
+      '3': {name: variable.parameter.soy}
+
+  namespace:
+    name: meta.tag.namespace.soy
+    begin: (\{)(namespace)\s+([\w\.]+)
+    beginCaptures:
+      '1': {name: punctuation.definition.tag.begin.soy}
+      '2': {name: entity.name.tag.soy}
+      '3': {name: variable.parameter.soy}
+    end: (\})
+    endCaptures:
+      '1': {name: punctuation.definition.tag.end.soy}
+    patterns:
+    - match: (?<=template|deltemplate)\s+([\.\w]+)
+      captures:
+        '1': {name: entity.name.function.soy}
+    - include: '#cssattrs-single'
+    - include: '#cssattrs-double'
+
+  cssattrs-single:
+    name: meta.attrs.cssconfig.single
+    match: \b(cssbase|requirecss)[ ]?(=)[ ]?'?(\w+)'?
+    captures:
+      '1': {name: entity.other.attribute-name.soy}
+      '2': {name: keyword.operator.soy}
+      '3': {name: string.quoted.double.soy}
+
+  cssattrs-double:
+    name: meta.attrs.cssconfig.double
+    match: \b(cssbase|requirecss)[ ]?(=)[ ]?\"(\w+)\"
+    captures:
+      '1': {name: entity.other.attribute-name.soy}
+      '2': {name: keyword.operator.soy}
+      '3': {name: string.quoted.double.soy}
 
   number:
     name: constant.numeric
@@ -296,7 +375,7 @@ repository:
 
   param:
     name: meta.tag.param.soy
-    begin: (\{/?)\s*(param)
+    begin: (\{/?)\s*([@]?param[\?]?|@inject[\?]?)
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.soy}
       '2': {name: entity.name.tag.soy}
@@ -384,6 +463,7 @@ repository:
       '1': {name: punctuation.definition.tag.end.soy}
     patterns:
     - include: '#namespace'
+    - include: '#delpackage'
     - include: '#variable'
     - include: '#special-character'
     - include: '#tag-simple'
@@ -431,6 +511,8 @@ repository:
         '1': {name: entity.other.attribute-name.soy}
         '2': {name: keyword.operator.soy}
         '3': {name: string.quoted.single.soy}
+    - include: '#cssattrs-single'
+    - include: '#cssattrs-double'
 
   variable:
     name: variable.other.soy

--- a/Syntaxes/Soy.tmLanguage
+++ b/Syntaxes/Soy.tmLanguage
@@ -20,6 +20,10 @@
 	<array>
 		<dict>
 			<key>include</key>
+			<string>#namespace</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#template</string>
 		</dict>
 		<dict>
@@ -40,11 +44,23 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#comment-soy</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#call</string>
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#css</string>
+			<string>#css-call</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#xid</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#css-dec</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -183,6 +199,31 @@
 				</dict>
 			</array>
 		</dict>
+		<key>comment-soy</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{\#)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.begin.soy</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\#\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.end.soy</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>comment.block.soy</string>
+		</dict>
 		<key>comment-block</key>
 		<dict>
 			<key>begin</key>
@@ -268,7 +309,77 @@
 			<key>name</key>
 			<string>comment.line.double-slash.soy</string>
 		</dict>
-		<key>css</key>
+		<key>css-call</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{/?)\s*(css)\(?\'([\w.]+)\'\)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.css.soy</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.soy</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.call.css.soy</string>
+		</dict>
+		<key>xid</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{/?)\s*(xid)\(?\'([\w.]+)\'\)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.css.soy</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.soy</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.call.xid.soy</string>
+		</dict>
+		<key>css-dec</key>
 		<dict>
 			<key>begin</key>
 			<string>(\{/?)\s*(css)\b</string>
@@ -394,6 +505,10 @@
 				<dict>
 					<key>include</key>
 					<string>#comment-doc</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment-soy</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -524,7 +639,15 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#css</string>
+					<string>#css-call</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#xid</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#css-dec</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -696,7 +819,7 @@
 		<key>function</key>
 		<dict>
 			<key>match</key>
-			<string>\b(isFirst|isLast|index|hasData|length|keys|round|floor|ceiling|min|max|randomInt)\b</string>
+			<string>\b(isFirst|isLast|index|hasData|length|keys|round|floor|ceiling|min|max|randomInt|isNonnull)</string>
 			<key>name</key>
 			<string>support.function.soy</string>
 		</dict>
@@ -828,8 +951,10 @@
 				</dict>
 			</array>
 		</dict>
-		<key>namespace</key>
+		<key>delpackage</key>
 		<dict>
+			<key>match</key>
+			<string>(delpackage)\s+([\w\.]+)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -843,8 +968,52 @@
 					<string>variable.parameter.soy</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(namespace|delpackage)\s+([\w\.]+)</string>
+		</dict>
+		<key>namespace</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{)(namespace)\s+([\w\.]+)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.begin.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.soy</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.soy</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#cssattrs-single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cssattrs-double</string>
+				</dict>
+			</array>
+			<key>name</key>
+			<string>meta.tag.namespace.soy</string>
 		</dict>
 		<key>number</key>
 		<dict>
@@ -863,7 +1032,7 @@
 		<key>param</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{/?)\s*(param)</string>
+			<string>(\{/?)\s*([@]?param[\?]?|@inject[\?]?)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1124,6 +1293,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#delpackage</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#variable</string>
 				</dict>
 				<dict>
@@ -1167,10 +1340,60 @@
 			<key>name</key>
 			<string>entity.name.tag.soy</string>
 		</dict>
+		<key>cssattrs-single</key>
+		<dict>
+			<key>name</key>
+			<string>meta.attrs.cssconfig.single</string>
+			<key>match</key>
+			<string>\b(cssbase|requirecss)[ ]?(=)[ ]?'?([\w\.]+)'?</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.attribute-name.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.soy</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>cssattrs-double</key>
+		<dict>
+			<key>name</key>
+			<string>meta.attrs.cssconfig.double</string>
+			<key>match</key>
+			<string>\b(cssbase|requirecss)[ ]?(=)[ ]?\"([\w\.]+)\"</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.attribute-name.soy</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.soy</string>
+				</dict>
+			</dict>
+		</dict>
 		<key>template</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{/?)\s*(template|deltemplate)</string>
+			<string>(\{/?)\s*(template|deltemplate)\s?([\w\.]+)?</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1182,6 +1405,11 @@
 				<dict>
 					<key>name</key>
 					<string>entity.name.tag.soy</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.soy</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -1206,9 +1434,14 @@
 							<key>name</key>
 							<string>entity.name.function.soy</string>
 						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.soy</string>
+						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;=template|deltemplate)\s+([\.\w]+)</string>
+					<string>(template|deltemplate)\s+([\.\w]+)\s?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1297,6 +1530,14 @@
 					</dict>
 					<key>match</key>
 					<string>\b(autoescape)\s*(=)\s*('true'|'false'|'contextual')</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cssattrs-single</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#cssattrs-double</string>
 				</dict>
 			</array>
 		</dict>

--- a/example.soy
+++ b/example.soy
@@ -1,0 +1,56 @@
+/**
+ * I am a block comment
+ */
+{namespace hi}
+{namespace sup.yo}
+{namespace hello cssbase='sup' requirecss='bonjour'}
+{namespace hello cssbase="sup" requirecss="bonjour"}
+{delpackage some.package.here}
+
+{css GOOG}
+
+
+/**
+ * I am another block comment
+ */
+{template .sub private="true" cssbase='hello.a.path' requirecss = "hello"}
+	{@param subparam: string}  /** Some sub-param */
+	{@param hola: i.am.a.deep.Path}  /** Some proto */
+	{@param cls: string}  /** Hey again */
+	{@param? id: string}  /** Reporting in */
+
+	<b{if isNonnull($id) or floor(5) or randomInt() or isNonnull('hi')} id="{$id}"{/if} class='{$cls}'>
+		{$subparam}{sp}- {length($hola.hey)}
+		<span>
+			{msg desc="Some message description"}Some text{/msg}
+			{msg desc='Another message description'}Some more text{/msg}
+		</span>
+	</b>
+{/template}
+
+
+/**
+ * I am yet another block comment
+ */
+{template .sup cssbase = 'hello.this.is.a.path'}
+	{@param yo: string}  /* Hello */
+	{@param? hey: number}  // Sup
+	{@inject hola: i.am.a.deep.Path}
+
+	{# I am a Soy comment #}
+
+	<html>
+	<head>
+		<title>{$yo}</title>
+	</head>
+	<body id="{xid('yo')}" class="{css('hello')} {css(again.yo)}">
+		<b>{$hey ?: "Hello"}</b>
+		{call hello.sub data="all"}
+			{param subparam: "hello" /}
+			{param hola: $hola /}
+			{param cls: css('sup') /}
+			{param id: xid('hey') /}
+		{/call}
+	</body>
+	</html>
+{/template}

--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>Soy</string>
+	<string>Closure Templates (Soy)</string>
 	<key>ordering</key>
 	<array>
 		<string>C56846DE-CB9A-4DB5-9D38-DC417DEA4D5F</string>
@@ -15,8 +15,9 @@
 		<string>BE6A0B8A-34ED-4896-B600-2DFE41C7246A</string>
 		<string>6C86EAFA-06ED-47AC-83E4-2F2D28FD0E43</string>
 		<string>B5EF61E9-B4B3-4D9A-800C-75256D077973</string>
+		<string>69E9BC3A-510B-4D5D-9B7A-7ECF878871B3</string>
 	</array>
 	<key>uuid</key>
-	<string>956A2BF6-079E-4D57-BC3D-8DA43F0EE761</string>
+	<string>F194ECD7-BF42-4062-A8A1-C94AA4EC5250</string>
 </dict>
 </plist>


### PR DESCRIPTION
This changeset updates Soy syntax definitions to be up-to-date with the newest language features (namely, `@inject`), and adds support for features which were previously unavailable or undocumented.

Changes:
- [x] Rename package -> _Closure Templates (Soy)_
- [x] Add example Soy file, with examples of syntax
- [x] Add highlight preference point for CSS symbols (via `xid`/`css`)
- [x] Add support for `xid()` and `css()` (aside from `{css GOOG}`)
- [x] Add support for `{# soy comments #}`
- [x] Add support for recognizing `isNonnull()` function
- [x] Add `Makefile` which installs the package for Sublime Text 3 on macOS (mainly meant for testing)
- [x] Fix param declarations (which now use `@param`), and add support for `@inject` declarations
- [x] Add support for `cssbase` and `requirecss` attrs, on `{namespace}` and `{template}` declarations